### PR TITLE
Upcasting, scaling, masking and fused kernels to match Megatron-LM

### DIFF
--- a/src/transformers/models/gpt_bigcode/configuration_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/configuration_gpt_bigcode.py
@@ -165,7 +165,7 @@ class GPTBigCodeConfig(PretrainedConfig):
         use_cache=True,
         bos_token_id=50256,
         eos_token_id=50256,
-        attention_softmax_in_fp32=False,
+        attention_softmax_in_fp32=True,
         scale_attention_softmax_in_fp32=True,
         attention_type=AttentionType.MULTI_HEAD,
         **kwargs,

--- a/src/transformers/models/gpt_bigcode/configuration_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/configuration_gpt_bigcode.py
@@ -166,7 +166,7 @@ class GPTBigCodeConfig(PretrainedConfig):
         bos_token_id=50256,
         eos_token_id=50256,
         attention_softmax_in_fp32=False,
-        scale_attention_softmax_in_fp32=False,
+        scale_attention_softmax_in_fp32=True,
         attention_type=AttentionType.MULTI_HEAD,
         **kwargs,
     ):

--- a/src/transformers/models/gpt_bigcode/configuration_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/configuration_gpt_bigcode.py
@@ -165,8 +165,8 @@ class GPTBigCodeConfig(PretrainedConfig):
         use_cache=True,
         bos_token_id=50256,
         eos_token_id=50256,
-        scale_attn_by_inverse_layer_idx=False,
-        reorder_and_upcast_attn=False,
+        attention_softmax_in_fp32=False,
+        scale_attention_softmax_in_fp32=False,
         attention_type=AttentionType.MULTI_HEAD,
         **kwargs,
     ):
@@ -189,8 +189,8 @@ class GPTBigCodeConfig(PretrainedConfig):
         self.summary_proj_to_labels = summary_proj_to_labels
         self.scale_attn_weights = scale_attn_weights
         self.use_cache = use_cache
-        self.scale_attn_by_inverse_layer_idx = scale_attn_by_inverse_layer_idx
-        self.reorder_and_upcast_attn = reorder_and_upcast_attn
+        self.attention_softmax_in_fp32 = attention_softmax_in_fp32
+        self.scale_attention_softmax_in_fp32 = scale_attention_softmax_in_fp32
 
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id

--- a/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -23,7 +23,6 @@ from typing import Optional, Tuple, Union
 import torch
 import torch.utils.checkpoint
 from torch import nn
-from torch.cuda.amp import autocast
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
 from ...activations import ACT2FN
@@ -118,14 +117,6 @@ def load_tf_weights_in_gpt_bigcode(model, config, gpt_bigcode_checkpoint_path):
 class GPTBigCodeAttention(nn.Module):
     def __init__(self, config, is_cross_attention=False, layer_idx=None):
         super().__init__()
-
-        max_positions = config.max_position_embeddings
-        self.register_buffer(
-            "bias", torch.tril(torch.ones((max_positions, max_positions), dtype=torch.bool)), persistent=False
-        )
-        self.register_buffer("masked_bias", torch.tensor(-1e4), persistent=False)
-        # We don't use a buffer because the mask value depends on the dtype,
-        # And the dtype will be different if upcasting.
         self.mask_value = None
 
         self.attention_type = AttentionType(config.attention_type)
@@ -146,17 +137,12 @@ class GPTBigCodeAttention(nn.Module):
         self.scale_attn_weights = config.scale_attn_weights
         self.is_cross_attention = is_cross_attention
 
-        # Layer-wise attention scaling, reordering, and upcasting
-        self.scale_attn_by_inverse_layer_idx = config.scale_attn_by_inverse_layer_idx
         self.layer_idx = layer_idx
-        self.reorder_and_upcast_attn = config.reorder_and_upcast_attn
-
-        self.scale_factor = 1.0
-        if self.scale_attn_weights:
-            self.scale_factor /= self.head_dim**0.5
-
-        if self.scale_attn_by_inverse_layer_idx:
-            self.scale_factor /= self.layer_idx + 1
+        self.attention_softmax_in_fp32 = config.attention_softmax_in_fp32
+        # TODO: This is only useful in fp16
+        self.scale_attention_softmax_in_fp32 = (
+            config.scale_attention_softmax_in_fp32 and config.attention_softmax_in_fp32
+        )
 
         if self.is_cross_attention:
             if self.is_mqa:
@@ -215,42 +201,31 @@ class GPTBigCodeAttention(nn.Module):
         z = torch.baddbmm(z, x, y, beta=0, alpha=scale_factor)
         return z.view(output_shape)
 
-    def _attn(self, query, key, value, attention_mask=None, head_mask=None, upcast=False):
-        with autocast(enabled=False):
-            attn_weights = self._matmul(
-                query, key.transpose(-1, -2), dtype=torch.float32 if upcast else None, scale_factor=self.scale_factor
-            )
+    def _attn(self, query, key, value, attention_mask=None, head_mask=None):
+        # TODO: Upcast has a big overhead, too many extra kernels. Try fusing?
+        dtype = query.dtype
+        softmax_dtype = torch.float32 if self.attention_softmax_in_fp32 else dtype
 
-        if not self.is_cross_attention:
-            # if only "normal" attention layer implements causal mask
-            key_length = key.size(-2)
-            if self.is_mqa:
-                # (b, sq, nh, sk)
-                causal_mask = self.bias[None, key_length - query.size(1) : key_length, None, :key_length]
-            else:
-                # (b, nh, sq, sk)
-                causal_mask = self.bias[None, None, key_length - query.size(-2) : key_length, :key_length]
-            # torch.where expects a tensor. We use a cache to avoid recreating it every time.
-            if (
-                self.mask_value is None
-                or self.mask_value.dtype != attn_weights.dtype
-                or self.mask_value.device != attn_weights.device
-            ):
-                self.mask_value = torch.full(
-                    [], torch.finfo(attn_weights.dtype).min, dtype=attn_weights.dtype, device=attn_weights.device
-                )
-            attn_weights = torch.where(causal_mask, attn_weights, self.mask_value)
+        unscale = self.layer_idx + 1 if self.scale_attention_softmax_in_fp32 and softmax_dtype != dtype else 1
+        scale_factor = unscale**-1
+        if self.scale_attn_weights:
+            scale_factor /= self.head_dim**0.5
+
+        attn_weights = self._matmul(query, key.transpose(-1, -2), scale_factor=scale_factor)
+
+        # Upcast implicitly in the next op to avoid an extra kernel.
+        if unscale != 1:
+            attn_weights = attn_weights * torch.full([1], unscale, dtype=softmax_dtype, device=attn_weights.device)
+            assert attn_weights.dtype == softmax_dtype
 
         if attention_mask is not None:
-            # Apply the attention mask
-            attn_weights = attn_weights + attention_mask
+            mask_value = torch.full(
+                [], torch.finfo(attn_weights.dtype).min, dtype=attn_weights.dtype, device=attn_weights.device
+            )
+            attn_weights = torch.where(attention_mask, attn_weights.to(dtype=softmax_dtype), mask_value)
 
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1)
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=softmax_dtype).to(query.dtype)
 
-        # Downcast (if necessary) back to V's dtype (if in mixed-precision) -- No-Op otherwise
-        if upcast and attn_weights.dtype != torch.float32:
-            raise RuntimeError("Error with upcasting, attn_weights does not have dtype torch.float32")
-        attn_weights = attn_weights.type(value.dtype)
         attn_weights = self.attn_dropout(attn_weights)
 
         # Mask heads if we want to
@@ -323,9 +298,7 @@ class GPTBigCodeAttention(nn.Module):
         else:
             present = None
 
-        attn_output, attn_weights = self._attn(
-            query, key, value, attention_mask, head_mask, upcast=self.reorder_and_upcast_attn
-        )
+        attn_output, attn_weights = self._attn(query, key, value, attention_mask, head_mask)
 
         attn_output = self._merge_heads(attn_output, self.num_heads, self.head_dim, permute=not self.is_mqa)
         attn_output = self.c_proj(attn_output)
@@ -669,7 +642,8 @@ class GPTBigCodeModel(GPTBigCodePreTrainedModel):
 
     def __init__(self, config):
         super().__init__(config)
-
+        self.attention_type = AttentionType(config.attention_type)
+        self.is_mqa = self.attention_type != AttentionType.MULTI_HEAD
         self.embed_dim = config.hidden_size
 
         self.wte = nn.Embedding(config.vocab_size, self.embed_dim)
@@ -678,6 +652,11 @@ class GPTBigCodeModel(GPTBigCodePreTrainedModel):
         self.drop = nn.Dropout(config.embd_pdrop)
         self.h = nn.ModuleList([GPTBigCodeBlock(config, layer_idx=i) for i in range(config.num_hidden_layers)])
         self.ln_f = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_epsilon)
+
+        max_positions = config.max_position_embeddings
+        self.register_buffer(
+            "bias", torch.tril(torch.ones((max_positions, max_positions), dtype=torch.bool)), persistent=False
+        )
 
         # Model parallel
         self.model_parallel = False
@@ -774,6 +753,9 @@ class GPTBigCodeModel(GPTBigCodePreTrainedModel):
         else:
             raise ValueError("You have to specify either input_ids or inputs_embeds")
 
+        if batch_size <= 0:
+            raise ValueError("batch_size has to be defined and > 0")
+
         device = input_ids.device if input_ids is not None else inputs_embeds.device
 
         if token_type_ids is not None:
@@ -790,34 +772,28 @@ class GPTBigCodeModel(GPTBigCodePreTrainedModel):
             position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
             position_ids = position_ids.unsqueeze(0).view(-1, input_shape[-1])
 
-        # GPTBigCodeAttention mask.
-        if attention_mask is not None:
-            if batch_size <= 0:
-                raise ValueError("batch_size has to be defined and > 0")
-            attention_mask = attention_mask.view(batch_size, -1)
-            # We create a 3D attention mask from a 2D tensor mask.
-            # Sizes are [batch_size, 1, 1, to_seq_length]
-            # So we can broadcast to [batch_size, num_heads, from_seq_length, to_seq_length]
-            # this attention mask is more simple than the triangular masking of causal attention
-            # used in OpenAI GPT, we just need to prepare the broadcast dimension here.
-            attention_mask = attention_mask[:, None, None, :]
+        # Self-attention mask.
+        query_length = input_shape[-1]
+        key_length = past_length + query_length
+        self_attention_mask = self.bias[None, key_length - query_length : key_length, :key_length]
 
-            # Since attention_mask is 1.0 for positions we want to attend and 0.0 for
-            # masked positions, this operation will create a tensor which is 0.0 for
-            # positions we want to attend and the dtype's smallest value for masked positions.
-            # Since we are adding it to the raw scores before the softmax, this is
-            # effectively the same as removing these entirely.
-            attention_mask = attention_mask.to(dtype=self.dtype)  # fp16 compatibility
-            attention_mask = (1.0 - attention_mask) * torch.finfo(self.dtype).min
+        if attention_mask is not None:
+            self_attention_mask = self_attention_mask * attention_mask.view(batch_size, 1, -1).bool()
+        # MQA: (b, sq, nh, sk)
+        # MHA: (b, nh, sq, sk)
+        attention_mask = self_attention_mask.unsqueeze(2 if self.is_mqa else 1)
 
         # If a 2D or 3D attention mask is provided for the cross-attention
         # we need to make broadcastable to [batch_size, num_heads, seq_length, seq_length]
-        if self.config.add_cross_attention and encoder_hidden_states is not None:
-            encoder_batch_size, encoder_sequence_length, _ = encoder_hidden_states.size()
-            encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
-            if encoder_attention_mask is None:
-                encoder_attention_mask = torch.ones(encoder_hidden_shape, device=device)
-            encoder_attention_mask = self.invert_attention_mask(encoder_attention_mask)
+        if (
+            self.config.add_cross_attention
+            and encoder_hidden_states is not None
+            and encoder_attention_mask is not None
+        ):
+            if encoder_attention_mask.dim() == 2:
+                encoder_attention_mask.unsqueeze(1)
+            assert encoder_attention_mask.dim() == 3
+            encoder_attention_mask = encoder_attention_mask.bool().unsqueeze(2 if self.is_mqa else 1)
         else:
             encoder_attention_mask = None
 


### PR DESCRIPTION
Run the following sequence (when enabled):
* attn_weights = (query x key) / sqrt(head_dim) / (layer_idx+1) [Single kernel, I think that's needed to stabilize fp16]
* Convert to fp32
* multiply by (layer_idx+1)
* Apply mask
* Softmax
* Convert to fp16

The whole thing runs in 2 kernels with jit fusion. Cuda time inference benchmark:
* Without jit: 793.142ms
* With jit: 751.869ms

Without upcast, the sequence is:
Run the following sequence (when enabled):
* attn_weights = (query x key) / sqrt(head_dim)
* Apply mask
* Softmax

Jit can reduce it to 2 kernels:
* Without jit: 745.253ms
* With jit: 751.365ms

Jit looks slower so I disabled it.

Overall, jit fusion allows fp32 softmax with minimal overhead (0.9% instead of 6.4%) and without the complicated custom kernels from Megatron.