### PR TITLE
More optimizations

### DIFF
--- a/src/transformers/models/gpt_bigcode/configuration_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/configuration_gpt_bigcode.py
@@ -194,8 +194,7 @@ class GPTBigCodeConfig(PretrainedConfig):
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id
 
-        # Convert to an int so it's JSON-serializable.
-        self.attention_type = AttentionType(attention_type).value
+        self.attention_type = AttentionType(attention_type)
 
         super().__init__(bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
 

--- a/src/transformers/models/megatron_gpt_bigcode/convert_megatron_gpt_bigcode_checkpoint.py
+++ b/src/transformers/models/megatron_gpt_bigcode/convert_megatron_gpt_bigcode_checkpoint.py
@@ -112,6 +112,7 @@ def convert_megatron_checkpoint(args, input_state_dict, config):
         config.n_inner = ds_args.ffn_hidden_size
 
         if ds_args.attention_head_type == "multihead":
+            # TODO: Adjust qkv layout (no need to fix_query_key_value_ordering anymore)
             config.attention_type = 1
         else:
             assert ds_args.attention_head_type == "multiquery"
@@ -200,16 +201,12 @@ def convert_megatron_checkpoint(args, input_state_dict, config):
             op_name == "attention.query_key_value" or op_name == "self_attention.query_key_value"
         ) and weight_or_bias == "weight":
             out_val = fix_query_key_value_ordering(val, checkpoint_version, 3, heads, hidden_size_per_head)
-            # Megatron stores (3*D) x D but transformers-GPT2 expects D x 3*D.
-            out_val = out_val.transpose(0, 1).contiguous()
             # Store.
             output_state_dict[layer_name + ".attn.c_attn.weight"] = out_val
 
         # Tranpose the Q matrix (for MQA)
         elif (op_name == "self_attention.query") and weight_or_bias == "weight":
             out_val = fix_query_key_value_ordering(val, checkpoint_version, 1, heads, hidden_size_per_head)
-            # Megatron stores (out x in) but transformers-GPT2 expects (in x out).
-            out_val = out_val.transpose(0, 1).contiguous()
             # Store.
             output_state_dict[layer_name + ".attn.q_attn.weight"] = out_val
 
@@ -217,13 +214,11 @@ def convert_megatron_checkpoint(args, input_state_dict, config):
         elif (op_name == "self_attention.key_value") and weight_or_bias == "weight":
             # Key-values are shared across heads
             out_val = fix_query_key_value_ordering(val, checkpoint_version, 2, 1, hidden_size_per_head)
-            # Megatron stores (out x in) but transformers-GPT2 expects (in x out).
-            out_val = out_val.transpose(0, 1).contiguous()
             if args.merge_qkv:
                 # Concatenate the tensors.
                 # Query is before key_value in the dict.
                 query = output_state_dict.pop(layer_name + ".attn.q_attn.weight")
-                out_val = torch.cat([query, out_val], dim=1)
+                out_val = torch.cat([query, out_val], dim=0)
                 output_state_dict[layer_name + ".attn.c_attn.weight"] = out_val
             else:
                 # Store.
@@ -259,11 +254,11 @@ def convert_megatron_checkpoint(args, input_state_dict, config):
                 # Store. No change of shape.
                 output_state_dict[layer_name + ".attn.kv_attn.bias"] = out_val
 
-        # Transpose the weights.
+        # Copy the weights.
         elif weight_or_bias == "weight":
 
             out_name = megatron_to_transformers[op_name]
-            output_state_dict[layer_name + out_name + "weight"] = val.transpose(0, 1)
+            output_state_dict[layer_name + out_name + "weight"] = val
 
         # Copy the bias.
         elif weight_or_bias == "bias":

--- a/src/transformers/models/megatron_gpt_bigcode/convert_megatron_gpt_bigcode_checkpoint.py
+++ b/src/transformers/models/megatron_gpt_bigcode/convert_megatron_gpt_bigcode_checkpoint.py
@@ -77,6 +77,7 @@ NAME_MAP = {
     "self_attention.key_value": ".attn.kv_attn.",
 }
 
+
 def convert_megatron_checkpoint(input_state_dict, merge_qkv):
     # The converted output model.
     output_state_dict = {}
@@ -154,7 +155,6 @@ def convert_megatron_checkpoint(input_state_dict, merge_qkv):
 
     # The regex to extract layer names.
     layer_re = re.compile("layers\.(\d+)\.([a-z0-9_.]+)\.([a-z]+)")
-
 
     # Extract the layers.
     for key, val in transformer.items():

--- a/src/transformers/models/megatron_gpt_bigcode/convert_megatron_gpt_bigcode_checkpoint.py
+++ b/src/transformers/models/megatron_gpt_bigcode/convert_megatron_gpt_bigcode_checkpoint.py
@@ -32,8 +32,6 @@
 # in your path, i.e., /path/to/Megatron-DeepSpeed/
 #
 
-# TODO: Update this file
-
 import argparse
 import os
 import re
@@ -191,7 +189,7 @@ def convert_megatron_checkpoint(input_state_dict, merge_qkv):
             out_val = torch.cat([query, val], dim=0)
             output_state_dict[layer_name + ".attn.c_attn." + weight_or_bias] = out_val
 
-        # Copy the weights or biases.
+        # Copy the parameters.
         else:
             output_state_dict[layer_name + megatron_to_transformers[op_name] + weight_or_bias] = val
 

--- a/src/transformers/models/megatron_gpt_bigcode/push_checkpoints.py
+++ b/src/transformers/models/megatron_gpt_bigcode/push_checkpoints.py
@@ -4,8 +4,7 @@ import subprocess
 from pathlib import Path
 
 from huggingface_hub import Repository
-
-from .convert_megatron_gpt_bigcode_checkpoint import main as convert
+from transformers.models.megatron_gpt_bigcode.convert_megatron_gpt_bigcode_checkpoint import main as convert
 
 
 """

--- a/tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py
+++ b/tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py
@@ -17,8 +17,8 @@
 import datetime
 import math
 import unittest
-from parameterized import parameterized
 
+from parameterized import parameterized
 from transformers import GPTBigCodeConfig, is_torch_available
 from transformers.testing_utils import require_torch, slow, torch_device
 
@@ -40,7 +40,6 @@ if is_torch_available():
         GPTBigCodeLMHeadModel,
         GPTBigCodeModel,
     )
-
     from transformers.models.gpt_bigcode.configuration_gpt_bigcode import AttentionType
     from transformers.models.gpt_bigcode.modeling_gpt_bigcode import GPTBigCodeAttention
 


### PR DESCRIPTION
* Use linear layers instead of Conv1d. (CPU, GPU optimization)
* Merge the key and value caches, and change how layer_past/presents is stored. (CPU, GPU)
* Change the memory layout of MHA key-value from `(2, self.num_heads, self.head_dim)` to `(self.num_heads, 2, self.head_dim)` as needed to merge the caches efficiently. This is different from transformers GPT2, but it now matches Megatron-LM. (GPU)
* Avoid redundant views from split_heads and merge_heads with MQA. Also move these functions inline (CPU)
* Remove `_matmul` and put back specialized versions in `_attn` to save some cpu time. (CPU).
* Adapt the conversion script to the new memory layout and trim it down.
* New converted model is in the `linear` branch of `bigcode/santacoder-fast-inference`.